### PR TITLE
Fix backup function collision loop and usage comment

### DIFF
--- a/functions
+++ b/functions
@@ -10,7 +10,7 @@ function abspath () {
 
 function backup () {
    # purpose: adds suffix to file or directory
-   # usage: backup <file|directory> [suffix=.bkp]
+   # usage: backup <file|directory> [suffix=bak]
    # example: backup myfile
 
    (( $# == 1 || $# == 2 )) || return 1
@@ -20,8 +20,9 @@ function backup () {
    local out_path="$in_path.$suffix"
    local index=2
 
+   local base_path="$out_path"
    while [[ -f "$out_path" || -d "$out_path" ]]; do
-      out_path="${out_path}${index}"
+      out_path="${base_path}${index}"
       (( index++ ))
    done
 


### PR DESCRIPTION
## Summary
- **Collision loop bug**: The `backup` function was cumulatively appending the index to `out_path`, producing paths like `file.bak2`, `file.bak23`, `file.bak234` instead of `file.bak2`, `file.bak3`, `file.bak4`. Introduced a `base_path` variable so each iteration rebuilds from the original path.
- **Usage comment**: Corrected `[suffix=.bkp]` to `[suffix=bak]` to match the actual default value.

## Test plan
- [x] Verify `backup myfile` produces `myfile.bak`, and with an existing `myfile.bak`, produces `myfile.bak2` (not `myfile.bak2` then `myfile.bak23`)
- [x] Verify `backup myfile custom` uses `custom` as the suffix